### PR TITLE
Serieller Output für apply_profile.code / mehr Infos für unbekannte Hardware

### DIFF
--- a/openwrt-addons/etc/init.d/set_etc_hardware
+++ b/openwrt-addons/etc/init.d/set_etc_hardware
@@ -11,7 +11,7 @@ boot()
             HARDWARE=$(grep ^machine /proc/cpuinfo | sed 's/.*: \(.*\)/\1/')
         }
         [ -z "$HARDWARE" ] && { 
-            HARDWARE="unknown" 
+            HARDWARE="unknown-$( uname -r)" 
         }
         echo "$HARDWARE" > /etc/HARDWARE
     fi

--- a/openwrt-build/apply_profile.code
+++ b/openwrt-build/apply_profile.code
@@ -2,6 +2,7 @@
 
 log()
 {
+    echo "$0: $1" >/dev/console
 	logger -s "$0: $1"
 }
 


### PR DESCRIPTION
2 kleine Patches

 c22fcc9 ..hatte ich etwas vorschnell entfernt... 

dann noch ein kleiner Patch, dass wenn die Hardware nicht erkannt werden kann, wenigstens noch die Architektur bekannt ist.. also z.B. x86-64 oder mips oder powerpc oder so... 

hängt mit #60 zusammen und wurde in 4d613b529e5b5e1adaeb1dbfc83a20df9cf2d928 von mir rausgenommen... 
