### PR TITLE
fix _list shuffle 

### DIFF
--- a/openwrt-addons/etc/kalua/list
+++ b/openwrt-addons/etc/kalua/list
@@ -64,9 +64,9 @@ _list_shuffle()
 
         
 	[ "$option" = 'get_first_random' ] && {
-	        list=$(echo "$list" | tr ' ' '\n' | shuf | head -n1)
+	        list=$(echo "$list" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -s ' ' '\n' | shuf | head -n1)
         } || {
-            list=$(echo "$list" | tr ' ' '\n' | shuf | tr '\n' ' ')
+            list=$(echo "$list" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -s ' ' '\n' | shuf | tr '\n' ' ')
 	}
         echo "$list" 
 

--- a/openwrt-addons/etc/kalua/list
+++ b/openwrt-addons/etc/kalua/list
@@ -52,10 +52,7 @@ _list_shuffle()
 {
 	local list="$1"
 	local option="$2"	# <empty> or 'get_first_random'
-	local list_size="$( _list count_elements "$list" )"
-	local sorted=0
-	local obj i
-
+        local list_size=$(_list count_elements "$list")
 	[ "$list_size" = 1 ] && {
 		echo "$list"
 		return 0
@@ -64,22 +61,12 @@ _list_shuffle()
 	_log do list_shuffle daemon debug "sorting list with $list_size elements"
 	_stopwatch start "list_shuffle_$list_size"
 
-	while [ $sorted -ne $list_size ]; do {
-
-		i=0
-		for obj in $list; do {
-			i=$(( i + 1 ))
-
-			[ "$( _math random_integer 1 $( _list count_elements "$list" ) )" = "1" ] && {
-				echo "$obj"
-
-				[ "$option" = 'get_first_random' ] && return 0
-				sorted=$(( sorted + 1 ))
-				list="$( _list remove_element "$list" "$i" )"
-				break
-			}
-		} done
-	} done
+        
+	[ "$option" = 'get_first_random' ] && {
+	        echo "$list" | tr ' ' '\n' | shuf | head -n1
+        } || {
+                echo "$list" | tr ' ' '\n' | shuf | tr '\n' ' '
+	}
 
 	_stopwatch stop "list_shuffle_$list_size" quiet
 }

--- a/openwrt-addons/etc/kalua/list
+++ b/openwrt-addons/etc/kalua/list
@@ -52,7 +52,8 @@ _list_shuffle()
 {
 	local list="$1"
 	local option="$2"	# <empty> or 'get_first_random'
-        local list_size=$(_list count_elements "$list")
+    local list_size=$(_list count_elements "$list")
+
 	[ "$list_size" = 1 ] && {
 		echo "$list"
 		return 0
@@ -63,10 +64,11 @@ _list_shuffle()
 
         
 	[ "$option" = 'get_first_random' ] && {
-	        echo "$list" | tr ' ' '\n' | shuf | head -n1
+	        list=$(echo "$list" | tr ' ' '\n' | shuf | head -n1)
         } || {
-                echo "$list" | tr ' ' '\n' | shuf | tr '\n' ' '
+            list=$(echo "$list" | tr ' ' '\n' | shuf | tr '\n' ' ')
 	}
+        echo "$list" 
 
 	_stopwatch stop "list_shuffle_$list_size" quiet
 }

--- a/openwrt-addons/usr/bin/shuf
+++ b/openwrt-addons/usr/bin/shuf
@@ -1,0 +1,25 @@
+#!/usr/bin/awk -f
+
+# Shuffle an _array_ with indexes from 1 to _len_.
+function shuffle(array, len, i, j, t) {
+	for (i = len; i > 1; i--) {
+		# j = random integer from 1 to i
+		j = int(i * rand()) + 1
+		# swap array[i], array[j]
+		t = array[i]
+		array[i] = array[j]
+		array[j] = t
+	}
+}
+
+BEGIN {
+ "cat /dev/urandom| tr -dc '0-9' | head -c8" | getline seed 
+ srand(seed)
+}
+{ 
+    lines[++len]=$0 
+}
+END {
+  shuffle(lines, len);
+  for (i = 1; i < len+1; i++) printf "%s\n", lines[i]
+}


### PR DESCRIPTION
commit 97508ccead4f5293da92ea69bc9190cdf55dac18
Author: mt <mt@i3o.de>
Date:   Sun Sep 13 16:34:12 2015 +0200

    use awk shuf for list shuffling
    
    - it's faster shuffling a list of 10000 items only takes 3 seconds on a
      841N - the current implementation doesn't even manage to shuffle such
    a large list
    
    - it's fairly random

commit 7a807c139331b775361c2a5973d61241deb32ed6
Author: mt <mt@i3o.de>
Date:   Sun Sep 13 16:32:12 2015 +0200

    awk implementation of shuf
    
    slightly adapted from http://rosettacode.org/wiki/Knuth_shuffle#AWK
    
    The PNRG is seeded by 8 bytes from /dev/urandom because awk srand()
    only seeds with the system time every second
