### PR TITLE
VPN fixes

### DIFF
--- a/openwrt-addons/etc/hotplug.d/iface/05-netfilter-wan
+++ b/openwrt-addons/etc/hotplug.d/iface/05-netfilter-wan
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+. /tmp/loader
+
+[ "$ACTION" = ifup -a "$INTERFACE" = "wan" ] && {
+	_log do "iface wan is up - starting masquerading"
+        _netfilter start 
+}

--- a/openwrt-addons/etc/kalua/netfilter
+++ b/openwrt-addons/etc/kalua/netfilter
@@ -28,9 +28,11 @@ _netfilter_start()
 		[ -n "$LOWMEM" ] && return 0
 	}
 
+    _vpn needed && _vpn block start
+
+
 	bool_true 'system.@weblogin[0].enabled' && {
 		[ -e "/www/SIMPLE_MESHNODE" ] || {
-			_vpn needed && _vpn blocking start
 			_netfilter splash_start
 			echo >>$SCHEDULER '_netfilter splash_autoadd'
 		}
@@ -797,8 +799,14 @@ _netfilter_masquerade_start()
 
 	_log do $funcname daemon info "active for device $device ($devname)"
 
-	echo "$IPT -t nat -D POSTROUTING -o $device -j MASQUERADE" >"$statfile"
-	$IPT -t nat -A POSTROUTING -o $device -j MASQUERADE
+    bool_true 'system.@system[0].restrict_local' && {
+            echo "$IPT -t nat -A POSTROUTING -o $device ! -d $WANNET/$WANPRE -j MASQUERADE" >"$statfile"
+	        $IPT -t nat -A POSTROUTING -o $device ! -d $WANNET/$WANPRE -j MASQUERADE
+    } || {
+            echo "$IPT -t nat -A POSTROUTING -o $device -j MASQUERADE" >"$statfile"
+            $IPT -t nat -A POSTROUTING -o $device -j MASQUERADE
+    }
+
 	$IPT -A FORWARD -i $device
 	$IPT -A FORWARD -o $device
 

--- a/openwrt-addons/etc/kalua/vpn
+++ b/openwrt-addons/etc/kalua/vpn
@@ -189,7 +189,7 @@ _vpn_needed()
 _vpn_start ()
 {
         lock -n /tmp/VPN_LOCK || {
-            _log "do" "_vpn start: Already locked! Aborting!"
+            logger -s -t vpn -p err "_vpn start already running. Aborting!"
             return 1
         }
 	local FUNC="vpn_start"
@@ -311,6 +311,7 @@ _vpn_write_vtun_conf()
 	local LINE=""
 	local STATIC_ROUTE="$( _vpn_get_static_route )"
 	local particpant_net="10.63.0.0/16"			# fixme! hardcoded
+        local kalua_roaming_net="192.168.0.0/16"
 	local mytable="weimarnetz_anonym"
 	local anonym
         local VPN_SERVER_IP="$(_net dns2ip $VPN_SERVER)"
@@ -337,6 +338,8 @@ Node$KNOT {
 
 		program "grep -q $mytable /etc/iproute2/rt_tables || echo 50 $mytable >>/etc/iproute2/rt_tables" wait;
 		program "$anonym ip rule add from $particpant_net prio 30010 table $mytable" wait;
+		program "$anonym ip rule add from $kalua_roaming_net iif "$WIFIDEV" prio 30020 table $mytable" wait;
+
 
 		# dont send packets to private networks over vpn
 		program "$anonym ip rule add to 169.254.0.0/24 prio 30005 lookup main" wait;
@@ -359,10 +362,13 @@ Node$KNOT {
 		program "$anonym ip rule del from $LANNET/$LANPRE prio 30000 table main" wait;
 		program "$anonym ip rule del to $particpant_net prio 30001 lookup main" wait;
 		#
-		program "$anonym ip rule del from 172.16.0.0/12 prio 30002 table $mytable" wait;
+		program "$anonym ip rule del to 172.16.0.0/12  prio 30002 lookup main" wait;
 		program "$anonym ip rule add to 192.168.0.0/16 prio 30003 lookup main" wait;
 		program "$anonym ip rule add to 10.0.0.0/8     prio 30004 lookup main" wait;
 		program "$anonym ip rule add to 169.254.0.0/24 prio 30005 lookup main" wait;
+
+		program "$anonym ip rule del from $kalua_roaming_net iif "$WIFIDEV" prio 30020 table $mytable" wait;    
+		program "$anonym ip rule del from $particpant_net prio 30010 table $mytable" wait;                   
 
 		program "ip route del $VPN_SERVER_IP via $STATIC_ROUTE" wait;
 		program "ip link set dev %% down" wait;
@@ -496,9 +502,7 @@ _vpn_build_vars()
 		test -n "$SERVER" -a "$CLIENTS" -ge 0 -a "$MTU" -ge 0 -a "$PORT" -ge 0 -a -n "$PING" 2>/dev/null
 	}
 
-       if [ -z "$PING" ]; then
-	    _log do $FUNC daemon info "ping not possible"
-       elif vars_are_sane; then
+       if vars_are_sane; then
              _log do ${FUNC} daemon notice "got ${SERVER} - ping: ${PING}ms"
 	     # here we build a long string:
 	     # each valid varset is a small mini-shell-script (eval-able)
@@ -515,6 +519,7 @@ _vpn_build_vars()
 
 # get a random VPN entry
 eval $( _list random_element "$TABLE" )
+
 
  VPN_SERVER="${SERVER}"
 

--- a/openwrt-addons/etc/kalua/vpn
+++ b/openwrt-addons/etc/kalua/vpn
@@ -188,6 +188,10 @@ _vpn_needed()
 
 _vpn_start ()
 {
+        lock -n /tmp/VPN_LOCK || {
+            _log "do" "_vpn start: Already locked! Aborting!"
+            exit 1
+        }
 	local FUNC="vpn_start"
 	_vpn_defer_start
 	_vpn needed || return 1
@@ -215,6 +219,7 @@ _vpn_start ()
 
 _vpn_stop ()
 {
+        rm /tmp/VPN_LOCK
 	_vpn_remove_vtun_conf
 	_vpn_tunnel_stop
 	
@@ -272,19 +277,15 @@ _vpn_tunnel_stop ()
 _vpn_tunnel_start ()
 {
 	local FUNC="vpn_tunnel_start"
-	[ -n "$PORT" ] && {
-		PORT="-P $PORT"
-	}
-	
 	[ ! -e "$VTUN" ] && {
 		_log do $FUNC daemon debug "no configfile - abort"
 		return
 	}
 	
 	
-	_log do $FUNC daemon debug "starting vtun with config '$VTUN'"
+	_log do $FUNC daemon debug "starting vtun with config '$VTUN $SERV $PORT'"
 
-	vtund -f "$VTUN" "Node$KNOT" "$SERV" "$PORT" 2>/dev/null || {
+	vtund -f "$VTUN" -P "$PORT" "Node$KNOT" "$SERV" 2>/dev/null || {
 
 		_log do $FUNC daemon debug "error"	
 		
@@ -312,6 +313,7 @@ _vpn_write_vtun_conf()
 	local particpant_net="10.63.0.0/16"			# fixme! hardcoded
 	local mytable="weimarnetz_anonym"
 	local anonym
+        local VPN_SERVER_IP="$(_net dns2ip $VPN_SERVER)"
 
 	[ -n "$( uci -q get system.@vpn[0].anonym )" ] && {
 		anonym="# (inactiv):"
@@ -331,7 +333,7 @@ Node$KNOT {
 		program "ip address add $WIFIVPNCLIENTADR/32 dev %%" wait;
 		program "ip -6 address add $VPN6ADR/$VPN6MSK dev %%" wait;
 		program "ip link set dev %% mtu $MTU up" wait;
-		program "ip route add $VPN_SERVER via $STATIC_ROUTE" wait;		# + table local?
+		program "ip route add $VPN_SERVER_IP via $STATIC_ROUTE" wait;		# + table local?
 
 		program "grep -q $mytable /etc/iproute2/rt_tables || echo 50 $mytable >>/etc/iproute2/rt_tables" wait;
 		program "$anonym ip rule add from $particpant_net prio 30010 table $mytable" wait;
@@ -347,7 +349,6 @@ Node$KNOT {
 		program "$anonym ip route add default via $WIFIVPNSERVERADR dev %% table $mytable" wait;
 
 		program "$anonym ip route flush cache" wait;
-		program ". /tmp/loader; _vpn include; _vpn blocking remove" wait;
 	} ;
 		# fixme! static_route must only be valid for programs on this machine
 	down {
@@ -363,9 +364,8 @@ Node$KNOT {
 		program "$anonym ip rule add to 10.0.0.0/8     prio 30004 lookup main" wait;
 		program "$anonym ip rule add to 169.254.0.0/24 prio 30005 lookup main" wait;
 
-		program "ip route del $VPN_SERVER via $STATIC_ROUTE" wait;
+		program "ip route del $VPN_SERVER_IP via $STATIC_ROUTE" wait;
 		program "ip link set dev %% down" wait;
-		program ". /tmp/loader; _vpn include; _vpn blocking start_after_all_connections_are_broken" wait;
 	} ;
 }
 EOF
@@ -394,23 +394,27 @@ _vpn_block()
 		'start')
 			bool_true 'system.vpn.force_block_wifi' && {
 				_log do $funcname daemon info 'start: wifi'
-				$IPT -I FORWARD ! -i $LANDEV -j REJECT
+                                for dev in $WIFI_DEVS; do
+					$IPT -I FORWARD -i "$dev" -o "$WANDEV" -j REJECT
+                                done
 			}
 
 			bool_true 'system.vpn.force_block_lan' && {
 				_log do $funcname daemon info 'start: lan'
-				$IPT -I FORWARD   -i $LANDEV -j REJECT
+				$IPT -I FORWARD -i "$LANDEV" -o "$WANDEV" -j REJECT
 			}
 		;;
 		'remove')
 			bool_true 'system.vpn.force_block_wifi' && {
 				_log do $funcname daemon info 'remove: wifi'
-				$IPT -D FORWARD ! -i $LANDEV -j REJECT
+				for dev in $WIFI_DEVS; do                                                           
+                                        $IPT -D FORWARD -i "$dev" -o "$WANDEV" -j REJECT                         
+                                done 
 			}
 
 			bool_true 'system.vpn.force_block_lan' && {
 				_log do $funcname daemon info 'remove: lan'
-				$IPT -D FORWARD   -i $LANDEV -j REJECT
+				$IPT -D FORWARD  -i "$LANDEV" -o "$WANDEV" -j REJECT
 			}
 		;;
 	esac

--- a/openwrt-addons/etc/kalua/vpn
+++ b/openwrt-addons/etc/kalua/vpn
@@ -190,7 +190,7 @@ _vpn_start ()
 {
         lock -n /tmp/VPN_LOCK || {
             _log "do" "_vpn start: Already locked! Aborting!"
-            exit 1
+            return 1
         }
 	local FUNC="vpn_start"
 	_vpn_defer_start

--- a/openwrt-addons/etc/kalua/vpn
+++ b/openwrt-addons/etc/kalua/vpn
@@ -338,7 +338,7 @@ Node$KNOT {
 
 		program "grep -q $mytable /etc/iproute2/rt_tables || echo 50 $mytable >>/etc/iproute2/rt_tables" wait;
 		program "$anonym ip rule add from $particpant_net prio 30010 table $mytable" wait;
-		program "$anonym ip rule add from $kalua_roaming_net iif "$WIFIDEV" prio 30020 table $mytable" wait;
+                program "$anonym ip rule add from $kalua_roaming_net iif "$WIFIDEV" prio 30020 table $mytable" wait;
 
 
 		# dont send packets to private networks over vpn
@@ -363,12 +363,12 @@ Node$KNOT {
 		program "$anonym ip rule del to $particpant_net prio 30001 lookup main" wait;
 		#
 		program "$anonym ip rule del to 172.16.0.0/12  prio 30002 lookup main" wait;
-		program "$anonym ip rule add to 192.168.0.0/16 prio 30003 lookup main" wait;
-		program "$anonym ip rule add to 10.0.0.0/8     prio 30004 lookup main" wait;
-		program "$anonym ip rule add to 169.254.0.0/24 prio 30005 lookup main" wait;
+		program "$anonym ip rule del to 192.168.0.0/16 prio 30003 lookup main" wait;
+		program "$anonym ip rule del to 10.0.0.0/8     prio 30004 lookup main" wait;
+		program "$anonym ip rule del to 169.254.0.0/24 prio 30005 lookup main" wait;
 
-		program "$anonym ip rule del from $kalua_roaming_net iif "$WIFIDEV" prio 30020 table $mytable" wait;    
-		program "$anonym ip rule del from $particpant_net prio 30010 table $mytable" wait;                   
+		program "$anonym ip rule del from $kalua_roaming_net iif "$WIFIDEV" prio 30020 table $mytable" wait;  
+                program "$anonym ip rule del from $particpant_net prio 30010 table $mytable" wait;                    
 
 		program "ip route del $VPN_SERVER_IP via $STATIC_ROUTE" wait;
 		program "ip link set dev %% down" wait;


### PR DESCRIPTION
Die Änderungen damit Blocking läuft. Die iptables-Regeln müssen gar nicht nicht entfernt werden... es wird einfach forwarding für Wifi oder LAN-Geräte nach WAN gesperrt... wenn der Tunnel läuft gehen die Daten über das tap-Device. Wenn Blocking nicht aktiviert ist, bleibt alles wie vorher. 

Zusätzlich gibt es noch die `restrict_local` Option... wenn Blocking nicht aktiviert ist, dann kann man damit den Zugriff auf das WAN-Netzwerk einschränken. 

Zusätzlich startet jetzt `_netfilter` über ein Hotplug-Script... lief sonst nicht für mich - und Zugriff auf WAN war weiterhin nach Boot möglich. 

Der Lock für `_vpn start` ist vielleicht nicht notwendig, aber ich hatte es jetzt mehrmals gesehen, dass das gleichzeitig ausgeführt wird und vielleicht hilft es ja da Probleme zu vermeiden. Jetzt klappt es immer auf anhieb. 

commit 379f80b729f2edf7b1b7308ea97b2bd6d40dc520
Author: mt <mt@i3o.de>
Date:   Sun Sep 13 18:46:16 2015 +0200

    Enable Masquerading more reliable when WAN comes up
    
    - Use a hotplug.d/iface script to start masquerading (_netfilter start)
      when the WAN interface is up. Otherwise it's not started
    - This assures that the VPN blocking rules are enabled at startup
      without delay

commit e38568376f7b1beb624dd06c08db669466de1161
Author: mt <mt@i3o.de>
Date:   Sun Sep 13 18:42:16 2015 +0200

    VPN changes
    
    - enable blocking of connections if the vpn is not up
    - enable restrict_local option to keep users from accessing the local
      lan
    - add a lockfile to _vpn start to avoid starting the vpn multiple times
      at once
