### PR TITLE
a standard toolset when log in via ssh

### DIFF
--- a/openwrt-addons/etc/profile.d/kalua.sh
+++ b/openwrt-addons/etc/profile.d/kalua.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+export PS1='\[\033[36m\]\u\[\033[m\]@\[\033[32m\]\h:\[\033[33;1m\]\w\[\033[m\] '
+
+alias n='wget -qO - http://127.0.0.1:2006/neighbours'
+alias n2='echo /nhdpinfo link | nc 127.0.0.1 2009'
+alias ll='ls -la'
+alias lr='logread'
+alias flush='_system ram_free flush'
+alias myssh='ssh -i $( _ssh key_public_fingerprint_get keyfilename )'
+alias regen='/etc/kalua_init; _(){ false;}; . /tmp/loader'
+
+case "$USER" in
+	'root')
+		grep -s ^"root:\$1\$b6usD77Q\$XPs6VECsQzFy9TUuQUAHW1:" '/etc/shadow' && {
+			echo "[ERROR] change weak root-password ('admin') with 'passwd'"
+		}
+
+		grep -s ^'root:$' '/etc/shadow' || {
+			echo "[ERROR] set root-password with 'passwd'"
+		}
+	;;
+esac
+
+_ t 2>/dev/null || {
+	[ -e '/tmp/loader' ] && {
+		. '/tmp/loader'
+		echo
+		echo 'for some hints type: _help overview'
+	}
+}

--- a/openwrt-build/apply_profile.code
+++ b/openwrt-build/apply_profile.code
@@ -1191,54 +1191,6 @@ _config_dhcp ()			# domain = .olsr
 	uci commit dhcp
 }
 
-_config_aliases ()
-{
-	local FILE="/etc/profile"
-	touch $FILE
-
-	grep -q ^"alias ll=" $FILE || {
-		log "writing ll"
-		echo >>$FILE "alias ll='ls -la'"
-	}
-
-	grep -q ^"alias flush=" $FILE || {
-		log "writing flush"
-		echo >>$FILE "alias flush='echo flushing_caches; echo 3 > /proc/sys/vm/drop_caches'"
-	}
-
-	grep -q ^"alias lr=" $FILE || {
-		log "writing logread-abbreviation: lf"
-		echo >>$FILE "alias lr='logread'"	
-	}
-
-	grep -q ^"alias regen=" $FILE || {
-		log "writing kalua-loader regen()"
-		echo >>$FILE "alias regen='/etc/kalua_init ;. /tmp/loader'"
-	}
-
-	fgrep -q "[ -e /tmp/loader" $FILE || {
-		log "writing kalua-loader -> autoloader"
-		echo >>$FILE "[ -e /tmp/loader ] && . /tmp/loader"
-	}
-
-	grep -q ^"alias n=" $FILE || {
-		log "writing alias 'neigh': use just keyword 'n' to see neighbours"
-		echo >>$FILE "alias n='wget -qO - http://127.0.0.1:2006/neighbours'"
-	}
-
-	grep -q "033" $FILE || {
-		log "writing better prompt"
-		echo >>$FILE 'export PS1="\[\033[36m\]\u\[\033[m\]@\[\033[32m\]\h:\[\033[33;1m\]\w\[\033[m\] "'
-	}
-
-	grep -q ^"alias myssh=" $FILE || {
-		log "alias myssh"
-		local KEY="/etc/dropbear/dropbear_dss_host_key"
-		local COMMAND="ssh -i $KEY"
-		echo >>$FILE "alias myssh='echo \"executing: $COMMAND\"; $COMMAND'"
-	}
-}
-
 _config_olsrd ()	# example here: http://olsr.org/git/?p=olsrd.git;a=blob;f=files/olsrd.conf.default.full
 {
 
@@ -1549,7 +1501,7 @@ EOF
 }
 
 # rewrite new settings
-for SECTION in softwareinstall wireless network system freifunk olsrd dhcp aliases; do {
+for SECTION in softwareinstall wireless network system freifunk olsrd dhcp; do {
 	log "....working on section '$SECTION'"
 	_config_$SECTION "$NODENUMBER"
 	log "[ok] ready with section '$SECTION'"


### PR DESCRIPTION
since r46965 with https://dev.openwrt.org/changeset/46965
we have profile.d support. use that.
we get e.g. a warning with weak or non-root password set

remove the now unneeded section in apply_profile