### PR TITLE
sync kalua-loader with upstream

### DIFF
--- a/openwrt-addons/etc/kalua_init
+++ b/openwrt-addons/etc/kalua_init
@@ -6,7 +6,7 @@
 # and automatically solve the dependencies for all 'classes' and it methods(),
 # e.g. for class '_system' and method architecture()
 #
-# TODO: method 'unload'
+# TODO: method 'unload' -> unset -f $funcname
 # TODO: method 'help'
 # TODO: show stats for each call: sed -n "s/^\(.*\) ().*/\1/p" $BASEDIR/$CLASS | wc -l | sed 's/ //g'
 
@@ -18,12 +18,14 @@ while read -r LINE; do {
 			set -- $LINE
 			mkdir -p "$2/kalua" 2>/dev/null && {
 				TMPDIR="$2/kalua"
+				LINE='is RAM-drive (tmpfs) and '
 				break
 			}
 		;;
 	esac
+	LINE=
 } done <'/proc/mounts'
-logger -s -- "$0: [OK] use \$TMPDIR which points to '${TMPDIR:=/tmp}'"
+logger -s -- "$0: [OK] use \$TMPDIR which ${LINE}points to '${TMPDIR:=/tmp}'"
 chmod -R 777 "$TMPDIR"
 
 # /etc/kalua_init -> /etc
@@ -47,8 +49,8 @@ mkdir -p "$POOLDIR"
 # _ http arg1 argX	-> include + start with given arguments
 # _ http		-> list methods and include
 # _ http include	-> include only
+# _ rebuild		-> rebuild loader
 # _ t			-> test if loader already included
-# _ r (or rebuild)	-> rebuild loader
 # _			-> list classes
 
 cat >"$LOADER" <<EOF
@@ -58,7 +60,7 @@ _ t 2>/dev/null&&return
 _(){ case \$1 in
 s)sed -n "/;}$/! s/^\(_\${2}_.*\)()/\1/p" $BASEDIR/\$2|sort;;
 i)local a=\${3-s} b=\$2;shift 3;_ \$b;case \$a in include);;*)_\${b}_\$a "\$@";;esac;;
-t);;r*)${BASEDIR}_init;;*)[ \$1 ]&&. $POOLDIR/\$1||for _ in $POOLDIR/*;do echo _\${_##*/};done;;esac;}
+t);;rebuild)${BASEDIR}_init;;*)[ \$1 ]&&. $POOLDIR/\$1||for _ in $POOLDIR/*;do echo _\${_##*/};done;;esac;}
 
 TMPDIR=$TMPDIR
 EOF

--- a/openwrt-addons/etc/kalua_init.user
+++ b/openwrt-addons/etc/kalua_init.user
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-# e.g. FFF_PLUS_VERSION
-[ -e '/etc/variables_fff+' ] && . '/etc/variables_fff+'
-
+# use the same PATH like interactive
 [ -e '/etc/profile' ] && {
 	command . '/etc/profile' >/dev/null
 	echo "export PATH=$PATH"
@@ -20,10 +18,10 @@ HOSTNAME="${HOSTNAME:-$( hostname 2>/dev/null || echo 'anonymous' )}"
 MONITORING_SERVERIP="$( uci -q get system.@monitoring[0].serverip )"
 MONITORING_SERVERIP="${MONITORING_SERVERIP:-84.38.67.43}"
 
-OPKG="$( which /bin/[o,i]pkg )"
+OPKG="$( command -v /bin/[o,i]pkg )"
 OPKG="${OPKG:-'_software opkg_raminstaller'}"
 
-# each node has it's own "neary uniq" DHCP-range
+# each node has it's own "nearly uniq" DHCP-range
 # which must be valid across the whole network,
 # e.g. 192.168.8.0/16 on node 8
 NODENUMBER_ROAMING="$( uci get system.@profile[0].nodenumber )"
@@ -45,6 +43,9 @@ mkdir -p "$PERMDIR" || {
 	logger -s -- "$0: fallback \$PERMDIR to '$PERMDIR'"
 }
 
+# e.g. FFF_PLUS_VERSION
+[ -e '/etc/variables_fff+' ] && . '/etc/variables_fff+'
+
 	cat <<EOF
 
 # from $0.user
@@ -60,8 +61,6 @@ export HOME=$( grep ^${USER:-root}: /etc/passwd | cut -d: -f6 )
 FFF_PLUS_VERSION=$FFF_PLUS_VERSION;OPENWRT_REV=$OPENWRT_REV
 PERMDIR=$PERMDIR
 
-isnumber(){ test 2>/dev/null \${1-a} -eq \$1;}
-bool_true(){ case \$(uci -q get \$1) in 1|on|true|yes|en*);;*)false;;esac;}
 EOF
 # isnumber: http://stackoverflow.com/questions/806906/how-do-i-test-if-a-variable-is-a-number-in-bash
 
@@ -86,7 +85,7 @@ else
 	echo 'IPT=iptables'
 fi
 
-echo "TC=$( which tc || echo 'false' )"		# TODO: wrapper function
+echo "TC=$( command -v tc || echo 'false' )"		# TODO: wrapper function
 
 if [ -e "$TMPDIR/NETPARAM" ]; then
 	FILE_NETPARAM="$TMPDIR/NETPARAM"
@@ -108,7 +107,7 @@ if [ -e "$FILE_NETPARAM" ]; then		# FIXME! better concept needed
 	printf '%s' "$WIFIDEV" >"$TMPDIR/WIFIDEV"	# is a hack for fast seeking our dev/ip
 	printf '%s' "$WIFIADR" >"$TMPDIR/WIFIADR"
 else
-        logger -s -- "$0: [OK] could not use '$FILE_NETPARAM' - maybe later"
+	logger -s -- "$0: [OK] could not use '$FILE_NETPARAM' - maybe later"
 fi
 
 [ $OPENWRT_REV -eq 0 -a -e '/etc/profile.d/kalua.sh' ] && cat <<EOF

--- a/openwrt-addons/etc/kalua_init.user_check_shell_interpreter
+++ b/openwrt-addons/etc/kalua_init.user_check_shell_interpreter
@@ -3,6 +3,16 @@
 case "$( readlink /bin/sh )" in
 	'dash')
 		# FIXME: a lot of scripts fail in dash
-		logger -s -- "$0: [ERR] please symlink your 'dash' = /bin/sh to /bin/bash: rm /bin/sh && ln -s /bin/bash /bin/sh"
+		logger -s -- "$0: [ERR] please symlink your 'dash' = /bin/sh to bash: rm /bin/sh && ln -s $( command -v bash ) /bin/sh"
+		[ -n "$TRAVIS" ] && sudo rm /bin/sh && sudo ln -s $( command -v bash ) /bin/sh
 	;;
 esac
+
+case "$( readlink /bin/sh )" in
+	*'bash')
+		# needed for 'explode'-alias
+		echo "case \$SHELL in *'bash') shopt -s expand_aliases ;; esac"
+	;;
+esac
+
+logger -s -- "$0: [OK] shell interpreter: '$( readlink /bin/sh )'"

--- a/openwrt-addons/etc/kalua_init.user_essential_helpers
+++ b/openwrt-addons/etc/kalua_init.user_essential_helpers
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# isnumber: http://stackoverflow.com/questions/806906/how-do-i-test-if-a-variable-is-a-number-in-bash
+cat <<EOF
+
+isnumber(){ test 2>/dev/null \${1-a} -eq \$1;}
+bool_true(){ case \$(uci -q get \$1) in 1|on|true|yes|en*);;*)false;;esac;}
+alias explode='set -f;set +f --'
+
+EOF

--- a/openwrt-addons/etc/kalua_init.user_fake_bad_iproute2
+++ b/openwrt-addons/etc/kalua_init.user_fake_bad_iproute2
@@ -32,7 +32,7 @@ ip() {
 					IP*|*'00:00:00:00:00:00'*)
 					;;
 					*)
-						set -- \$line
+						explode \$line
 						if [ -z "\$ip_wish" ]; then
 							echo "\$1 dev \$6 lladdr \$4 STALE"
 						elif [ "\$ip_wish" = "\$1" ]; then

--- a/openwrt-addons/etc/kalua_init.user_fake_missing_logread
+++ b/openwrt-addons/etc/kalua_init.user_fake_missing_logread
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-which logread >/dev/null || {
+command -v logread >/dev/null || {
 	# needed e.g. on vpn-server, $1 can be e.g. '-f'
 	# dont overload with travis, otherwise shellsheck complains about SC2119
 	[ -z "$TRAVIS" ] && echo "logread() { echo no_native_logread;tail -n300 /var/log/syslog \$1; }"

--- a/openwrt-addons/etc/kalua_init.user_fake_missing_uci
+++ b/openwrt-addons/etc/kalua_init.user_fake_missing_uci
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-which uci >/dev/null || {
+command -v uci >/dev/null || {
 	logger -s -- "$0: uci() faking OpenWrt-uci, use '/etc/kalua_uci' for your vars"
 	# when there is no output, we return with 0 (unlike to normal uci)
 	# FIXME! parsing var='value' (with quotes)
@@ -16,7 +16,7 @@ uci()	# e.g. uci -q get system.@profile[0].nodenumber
 
 	case "\$1" in
 		show)
-			[ -e /etc/kalua_uci ] && cat /etc/kalua_uci
+			grep -s \${2:+^}\${2:-.}\${2:+\.} /etc/kalua_uci
 		;;
 		set)
 			grep -q ^"\$2" /etc/kalua_uci || echo "\$2" >>/etc/kalua_uci


### PR DESCRIPTION
introduce new helper: explode
works like the common lisp equivalent of the maclisp function,
e.g. explode A B C; echo $2 -> B
and is globbing safe. so now we should rewrite all calls to
set -- $string
into
explode $string

add some portability things like:
which $program -> command -v $program

minor bugfix for classes beginning with 'r'
(luckily at the moment we have no class with such a name)