### PR TITLE
Fix possible memory leak in _vpn

### DIFF
--- a/openwrt-addons/etc/kalua/vpn
+++ b/openwrt-addons/etc/kalua/vpn
@@ -223,7 +223,7 @@ _vpn_start ()
 
 _vpn_stop ()
 {
-        rm '/tmp/VPN_LOCK'
+        lock -u '/tmp/VPN_LOCK'
 	_vpn_remove_vtun_conf
 	_vpn_tunnel_stop
 	


### PR DESCRIPTION
Creating new locks using `lock -n` without proper usage of `lock -u` seems to create dangling lock processes  that eat up memory. 

```
 2738 root      1352 S    lock -n /tmp/VPN_LOCK
 5553 root      1352 S    lock -n /tmp/VPN_LOCK
 6913 root      1352 S    lock -n /tmp/VPN_LOCK
 9191 root      1352 S    lock -n /tmp/VPN_LOCK
12361 root      1352 S    lock -n /tmp/VPN_LOCK
24440 root      1352 S    lock -n /tmp/VPN_LOCK
26783 root      1352 S    lock -n /tmp/VPN_LOCK
31715 root      1352 S    lock -n /tmp/VPN_LOCK
``` 
I'm not sure how much this eats `/proc/<pid>/status` indicates it's at least 400kb/process... 

```
root@s140:/www cat /proc/24440/status 
Name:   lock
State:  S (sleeping)
Tgid:   24440
Ngid:   0
Pid:    24440
PPid:   1
TracerPid:      0
Uid:    0       0       0       0
Gid:    0       0       0       0
FDSize: 32
Groups: 0 
VmPeak:     1352 kB
VmSize:     1352 kB
VmLck:         0 kB
VmPin:         0 kB
VmHWM:       408 kB
VmRSS:       268 kB
VmData:      344 kB
VmStk:       136 kB
VmExe:       284 kB
VmLib:       556 kB
VmPTE:        12 kB
VmSwap:       44 kB
Threads:        1
...
``` 


Sorry :/