### PR TITLE
vpn: 3 Modi werden nun unterstützt: Aus, An, nur Verbindung zur Wolke…

### DIFF
--- a/openwrt-addons/etc/kalua/vpn
+++ b/openwrt-addons/etc/kalua/vpn
@@ -182,7 +182,7 @@ _vpn_needed()
 		return 1
 	}
 
-	[ "$( uci -q get system.@vpn[0].enable )" = "1" ] || {
+	[ "$( uci -q get system.@vpn[0].enable )" = "off" ] && {
 		_log it $FUNC daemon debug "vpn disabled by config - abort"
 		return 1
 	}
@@ -320,7 +320,7 @@ _vpn_write_vtun_conf()
 	local anonym
         local VPN_SERVER_IP="$(_net dns2ip $VPN_SERVER)"
 
-	[ -n "$( uci -q get system.@vpn[0].anonym )" ] && {
+	[ -n "$( uci -q get system.@vpn[0].enable )" = "innercity" ] && {
 		anonym="# (inactiv):"
 	}
 

--- a/openwrt-addons/etc/kalua/vpn
+++ b/openwrt-addons/etc/kalua/vpn
@@ -320,7 +320,7 @@ _vpn_write_vtun_conf()
 	local anonym
         local VPN_SERVER_IP="$(_net dns2ip $VPN_SERVER)"
 
-	[ -n "$( uci -q get system.@vpn[0].enable )" = "innercity" ] && {
+	[ "$( uci -q get system.@vpn[0].enable )" = "innercity" ] && {
 		anonym="# (inactiv):"
 	}
 

--- a/openwrt-build/apply_profile.code
+++ b/openwrt-build/apply_profile.code
@@ -491,7 +491,7 @@ _config_system ()
 	uci set system.vpn.prefix="v"
 	uci set system.vpn.jsonpath="/freifunk/vpn/"
 	uci set system.vpn.proto="olsr"
-	uci set system.vpn.enable="1"
+	uci set system.vpn.enable="on"
 	uci set system.vpn.ipaddr="vpn.weimarnetz.de"
 
 	uci commit system


### PR DESCRIPTION
…. Variables werden auf Einstellungsseite gesetzt: https://github.com/weimarnetz/openwrt-packages/blob/master/utils/luci-weimar-splash/luasrc/model/cbi/weimarnetz/settings.lua, Standard ist An