### PR TITLE
kalua: init/loader: add new helper divisor_valid()

### DIFF
--- a/openwrt-addons/etc/kalua_init
+++ b/openwrt-addons/etc/kalua_init
@@ -12,7 +12,7 @@ while read -r LINE; do {		# e.g. none /run/user tmpfs rw,nosuid,nodev,noexec...
 	case "$LINE" in			# attribute 'noexec' does not matter,
 		*' tmpfs rw,'*)		# we only 'source' shellscripts
 			set -- $LINE
-			mkdir -p "$2/kalua" && {
+			mkdir -p "$2/kalua" 2>/dev/null && {
 				TMPDIR="$2/kalua"
 				LINE='is RAM-drive (tmpfs) and '
 				break
@@ -24,7 +24,7 @@ while read -r LINE; do {		# e.g. none /run/user tmpfs rw,nosuid,nodev,noexec...
 logger -s -- "$0: [OK] use \$TMPDIR which ${LINE}points to '${TMPDIR:=/tmp}'"
 chmod -R 777 "$TMPDIR"
 
-LOADER_ENTRY='/tmp/loader'
+LOADER_ENTRY='/tmp/loader'		# entry point for all scripts, should be in RAM-drive
 LOADER="$TMPDIR/loader_$$"
 LOADER_FINAL="$TMPDIR/loader"		# later '$LOADER_ENTRY' is symlinked to it
 POOLDIR="$TMPDIR/kalua_pool"
@@ -100,6 +100,6 @@ mv "$LOADER" "$LOADER_FINAL"
 logger -s -- "$0: [OK] generated '$LOADER_ENTRY' using files in '$POOLDIR'"
 case "$PS1" in
 	*'@'*)	# interactive shell (set from /etc/profile)
-		logger -s -- "$0: [OK] reload it with '_(){ false;}; . $LOADER_ENTRY'"
+		logger -s -- "$0: [OK] reload it with 'unset -f _; . $LOADER_ENTRY'"
 	;;
 esac

--- a/openwrt-addons/etc/kalua_init.user_essential_helpers
+++ b/openwrt-addons/etc/kalua_init.user_essential_helpers
@@ -4,6 +4,7 @@
 cat <<EOF
 
 isnumber(){ test 2>/dev/null \${1:-a} -eq "\${1##*[!0-9-]*}";}
+divisor_valid(){ isnumber \$1||return;case \$1 in 0|-0)false;;esac;}
 bool_true(){ case \$(uci -q get \$1) in 1|on|true|yes|en*);;*)false;;esac;}
 alias explode='set -f;set +f --'
 


### PR DESCRIPTION
please use it before every divison, e.g.

divisor_valid "$myvar" || myvar=1
x=$(( 1234 / myvar ))

or

divisor_valid "$myvar" || myvar=1
x=$(( 1234 % myvar ))

shell scripts break immediately if there is a
division by zero and we cannot catch this via a trap.
the macro adds only a very small amount of cpu-overhead.