### PR TITLE
kalua: loader: sync with upstream

### DIFF
--- a/openwrt-addons/etc/kalua_init
+++ b/openwrt-addons/etc/kalua_init
@@ -98,8 +98,10 @@ mv "$LOADER" "$LOADER_FINAL"
 }
 
 logger -s -- "$0: [OK] generated '$LOADER_ENTRY' using files in '$POOLDIR'"
-case "$PS1" in
-	*'@'*)	# interactive shell (set from /etc/profile)
+case "$PS1-display$DISPLAY" in
+	*'@'*|*'-display:'*)	# interactive shell (set from /etc/profile)
 		logger -s -- "$0: [OK] reload it with 'unset -f _; . $LOADER_ENTRY'"
+	;;
+	*)
 	;;
 esac

--- a/openwrt-addons/etc/kalua_init.user
+++ b/openwrt-addons/etc/kalua_init.user
@@ -87,10 +87,11 @@ fi
 
 echo "TC=$( command -v tc || echo 'false' )"		# TODO: wrapper function
 
-[ $OPENWRT_REV -eq 0 -a -e '/etc/profile.d/kalua.sh' ] && cat <<EOF
+# include helpers when 'interactive', e.g. SSH-login
+[ -e '/etc/profile.d/kalua.sh' ] && cat <<EOF
 case "\$-" in
 	*i*)
-		. /etc/profile.d/kalua.sh
+		fgrep -sq '/etc/profile.d' /etc/profile || . /etc/profile.d/kalua.sh
 	;;
 esac
 EOF

--- a/openwrt-addons/etc/kalua_init.user_essential_helpers
+++ b/openwrt-addons/etc/kalua_init.user_essential_helpers
@@ -5,7 +5,7 @@ cat <<EOF
 
 isnumber(){ test 2>/dev/null \${1:-a} -eq "\${1##*[!0-9-]*}";}
 divisor_valid(){ isnumber \$1||return;case \$1 in 0|-0)false;;esac;}
-bool_true(){ case \$(uci -q get \$1) in 1|on|true|yes|en*);;*)false;;esac;}
+bool_true(){ case \$(uci -q get "\$1") in 1|on|true|yes|en*);;*)false;;esac;}
 alias explode='set -f;set +f --'
 
 EOF


### PR DESCRIPTION
always load '/etc/profile.d/kalua.sh' when interactive
and it seems there is no profile.d support. fixed #204