### PR TITLE
kalua: software: opkg_raminstaller() sync with upstream

### DIFF
--- a/openwrt-addons/etc/kalua/software
+++ b/openwrt-addons/etc/kalua/software
@@ -462,3 +462,56 @@ _software_package_install()
 		# fixme! do cleanup, e.g. remove '/tmp/mydesign_0.2_29132.ipk'
 	fi
 }
+
+_software_opkg_raminstaller()
+{
+	# if the real 'opkg' is not installed/included, autodownload and call it with all args
+	local funcname='software_opkg_raminstaller'
+	local fake='/tmp/bin/opkg'
+	local arch url file
+
+	[ -e "$fake" ] || {
+		case "$( _system clib )" in
+			'musl')
+				# DISTRIB_TARGET='ramips/mt7620'
+				. /etc/openwrt_release
+				url="http://downloads.openwrt.org/snapshots/trunk/$DISTRIB_TARGET/packages/base"
+			;;
+			*)
+				arch="$( _system architecture )"
+				url="http://downloads.openwrt.org/barrier_breaker/14.07/$arch/generic/packages/base"
+			;;
+		esac
+
+		_log it $funcname daemon info "fetching filename from $url"
+		local file="$( wget -O - "$url" | fgrep 'opkg_' | cut -d'"' -f2 )"
+
+		url="$url/$file"
+		_log it $funcname daemon info "fetching package from '$url'"
+
+		(
+			cd /tmp || return
+			wget -O 'opkg.ipk' "$url"
+			tar xzf 'opkg.ipk'
+			rm 'debian-binary' 'control.tar.gz' 'opkg.ipk'
+			tar xvzf 'data.tar.gz' ./bin/opkg
+			rm 'data.tar.gz'
+		)
+	}
+
+	# TODO: this will fail, e.g. if the binary uses another clib than the router (musl VS uclibc)
+	# if something is wrong with the binary, install a stub which simulates OK
+	$fake -v | grep -q ^'opkg version' || {
+		{
+			echo '#!/bin/sh'
+			echo '. /tmp/loader'
+			echo "_log it $funcname daemon info 'please check binary from $url'"
+			echo 'true'
+		} >"$fake"
+
+		chmod +x "$fake"
+	}
+
+	# if on debian, it report via 'file opkg' -> 'corrupted section header size'
+	$fake "$@"
+}


### PR DESCRIPTION
the 'loader' automatically checks if 'opkg' is installed or not
and set the variable $OPKG according to this. When somebody wants
to install a package and the real 'opkg' is not in place yet it
will be fetched from internet and installed to ramdisk. so a call

$OPKG update
$OPKG install tcpdump-mini

will result in a normal install. when 'opkg' is not built
into the image, this can save ~50 kilobytes. discussed in #197
in another patch i will update the loader to also make this work
when 'opkg' is called directly.