### PR TITLE
kalua: loader: sync with upstream - 2 fixes

### DIFF
--- a/openwrt-addons/etc/kalua_init
+++ b/openwrt-addons/etc/kalua_init
@@ -8,9 +8,11 @@
 #  you will make somebody's life easier in the future.
 #  Maybe your own."
 
-while read -r LINE; do {		# e.g. none /run/user tmpfs rw,nosuid,nodev,noexec...
-	case "$LINE" in			# attribute 'noexec' does not matter,
-		*' tmpfs rw,'*)		# we only 'source' shellscripts
+while read -r LINE; do {	# e.g.	none /run/user tmpfs rw,nosuid,nodev,noexec...
+	case "$LINE" in		#	attribute 'noexec' does not matter...
+		*'size='[0-9]'k'*)
+		;;
+		*' tmpfs rw,'*)	#	...we only 'source' shellscripts
 			set -- $LINE
 			mkdir -p "$2/kalua" 2>/dev/null && {
 				TMPDIR="$2/kalua"

--- a/openwrt-addons/etc/kalua_init.user
+++ b/openwrt-addons/etc/kalua_init.user
@@ -16,18 +16,18 @@ HOSTNAME="$( uci -q get system.@system[0].hostname )"
 HOSTNAME="${HOSTNAME:-$( cat '/etc/hostname' )}"
 HOSTNAME="${HOSTNAME:-$( hostname 2>/dev/null || echo 'anonymous' )}"
 
-MONITORING_SERVERIP="$( uci -q get system.monitoring.serverip )"
+MONITORING_SERVERIP="$( uci -q get system.@monitoring[0].serverip )"
 MONITORING_SERVERIP="${MONITORING_SERVERIP:-84.38.67.43}"
 
 OPKG="$( command -v /bin/[o,i]pkg )" || {
 	echo "opkg(){ _software opkg_raminstaller \"\$@\";}"
-	OPKG='_software opkg_raminstaller'
+	OPKG="'_software opkg_raminstaller'"
 }
 
 # each node has it's own "nearly uniq" DHCP-range
 # which must be valid across the whole network,
 # e.g. 192.168.8.0/16 on node 8
-NODENUMBER_ROAMING="$( uci -q get system.profile.nodenumber )"
+NODENUMBER_ROAMING="$( uci -q get system.@profile[0].nodenumber )"
 while [ ${NODENUMBER_ROAMING:=2} -gt 254 ]; do {
 	NODENUMBER_ROAMING=$(( NODENUMBER_ROAMING - 254 ))	# e.g. node 255 -> 1
 } done
@@ -54,8 +54,8 @@ mkdir -p "$PERMDIR" 2>/dev/null || {
 # from $0.user @ $(date)
 export TZ='$TIMEZONE'
 NODENUMBER_ROAMING=$NODENUMBER_ROAMING
-NODENUMBER=\${NODENUMBER:-$( uci -q get system.profile.nodenumber )}
-CONFIG_PROFILE=\${CONFIG_PROFILE:-$( uci -q get system.profile.name )}
+NODENUMBER=\${NODENUMBER:-$( uci -q get system.@profile[0].nodenumber )}
+CONFIG_PROFILE=\${CONFIG_PROFILE:-$( uci -q get system.@profile[0].name )}
 HARDWARE='$HARDWARE'
 HOSTNAME='$HOSTNAME'
 OPKG=$OPKG

--- a/openwrt-addons/etc/kalua_init.user_fake_missing_uci
+++ b/openwrt-addons/etc/kalua_init.user_fake_missing_uci
@@ -6,7 +6,7 @@ command -v uci >/dev/null || {
 	# FIXME! parsing var='value' (with quotes)
 
 	cat >>"$LOADER" <<EOF
-uci()	# e.g. uci -q get system.profile.nodenumber
+uci()	# e.g. uci -q get system.@profile[0].nodenumber
 {
 	case "\$1" in
 		'-q')


### PR DESCRIPTION
avoid $TMPDIR pointing to very small disk
and fix $OPKG call when real opkg is missing
also fixing some uci-varnames.