### PR TITLE
remove ping from vpn check

### DIFF
--- a/openwrt-addons/etc/kalua/vpn
+++ b/openwrt-addons/etc/kalua/vpn
@@ -518,7 +518,7 @@ _vpn_build_vars()
 
 	vars_are_sane()
 	{
-		test -n "$SERVER" -a "$CLIENTS" -ge 0 -a "$MTU" -ge 0 -a "$PORT" -ge 0 -a -n "$PING" 2>/dev/null
+		test -n "$SERVER" -a "$CLIENTS" -ge 0 -a "$MTU" -ge 0 -a "$PORT" -ge 0" 2>/dev/null
 	}
 
        if vars_are_sane; then


### PR DESCRIPTION
fixes #224

ping is still in the logs but it's not mandatory for a successful connection.

special thanks to the braindead network guy who did this.