### PR TITLE
kalua: net: ping_getlatency() fix for '100% packet loss'

### DIFF
--- a/openwrt-addons/etc/kalua/net
+++ b/openwrt-addons/etc/kalua/net
@@ -15,14 +15,18 @@ _net_ping_getlatency()
 	local pings="${2:-3}"
 
 	# round-trip min/avg/max = 24.638/24.638/24.638 ms	// busybox
+	# or:                      ^^^^^^^^^^^^^^^^^^^^
+	# 3 packets transmitted, 0 packets received, 100% packet loss
+	#                       ^^^
 	# rtt min/avg/max/mdev = 33.415/33.415/33.415/0.000 ms	// debian
-	set -- $( ping -q -c${pings} -W1 "$server" 2>/dev/null | tail -n1 )
+	# or: <empty>
+	explode $( ping -q -c${pings} -W1 "$server" 2>/dev/null | tail -n1 )
 
 	# bad return on error
-	test -n "$4" &&	{
+	test -n "$4" -a "$4" != '0' &&	{
 		# round-trip min/avg/max = 15.887/24.931/42.406 ms
 		# -> 15.887/24.931/42.406 -> 15 887 24 931 42 406
-		local oldIFS="$IFS"; IFS=[/.]; set -- $4; IFS="$oldIFS"
+		local oldIFS="$IFS"; IFS='[/.]'; explode $4; IFS="$oldIFS"
 
 		# output 'average' round trip time: 24.931 -> 24
 		echo "$3"


### PR DESCRIPTION
without this fix it returns OK:
```
root@box:~ _net ping_getlatency 1.1.1.1

root@box:~ echo $?
0
```

with this fix:
```
root@box:~ _net ping_getlatency 1.1.1.1
root@box:~ echo $?
1
```
