### PR TITLE
make opkg usable on 32mb systems

### DIFF
--- a/openwrt-addons/etc/profile.d/opkg.sh
+++ b/openwrt-addons/etc/profile.d/opkg.sh
@@ -1,0 +1,7 @@
+#!/bin/sh 
+# make opkg work on system with 32mb 
+# see: https://github.com/lede-project/source/issues/237#issuecomment-242476551
+#      http://cgit.openembedded.org/openembedded/plain/recipes/opkg/files/opkg_use_vfork_gunzip.patch
+export OPKG_USE_VFORK=1 
+
+


### PR DESCRIPTION
siehe: http://cgit.openembedded.org/openembedded/plain/recipes/opkg/files/opkg_use_vfork_gunzip.patch

tl;dr: wenn man eine umgebungsvariable setzt, dann nutzt opkg das busybox gzip zum entpacken und nutzt vfork() was effizienter bezüglich der speichernutzung ist, standardmäßig nutzt opkg sein eigenes gunzip dafür ist allerdings fork() notwendig was mehr speicher benötigt. 

damit läuft opkg update und opkg install auch mit 32mb routern wieder. 