### PR TITLE
kalua: switch: query_mii() use 'devstatus' if available, so no need f…

### DIFF
--- a/openwrt-addons/etc/kalua/switch
+++ b/openwrt-addons/etc/kalua/switch
@@ -77,7 +77,7 @@ _switch_query_swconfig()	# SENSE: show a single switch-port of a 'swconfig'-cont
 		[ -n "$debug" ] && \
 			_log it $funcname daemon debug "type: $type port: $port line '$line'"
 
-		# why this lead to unkown? line: '     link: port:0 link:down'
+		# why this lead to unknown? line: '     link: port:0 link:down'
 
 		case "$line" in
 			*"link: port:$port link: down"*)
@@ -118,16 +118,16 @@ _switch_query_swconfig()	# SENSE: show a single switch-port of a 'swconfig'-cont
 	} done
 }
 
-_switch_query_miitool()		# SENSE: show a single switch-port of a 'mii-tool'-controlled switch
+_switch_query_mii()		# SENSE: show port of a 'MII'-interface
 {
-	local funcname='switch_query_miitool'
+	local funcname='switch_query_mii'
 	local port_list="$1"
 	local debug="$2"
 
 	local line port max_try duplex
 
 	for port in $port_list; do {
-		[ "$port" = "gap" ] && {
+		[ "$port" = 'gap' ] && {
 			_switch symbol gap
 			continue
 		}
@@ -135,10 +135,19 @@ _switch_query_miitool()		# SENSE: show a single switch-port of a 'mii-tool'-cont
 		line=
 		max_try=10
 		while [ -z "$line" ]; do {
-			if [ -e '/usr/sbin/ethtool' ]; then
-				line="$( /usr/sbin/ethtool "$port" )"
-			else
+			if   command -v 'devstatus' >/dev/null; then
+				line="$( devstatus "$port" | grep '"speed": ' )" && {
+					# e.g. "speed": "100F", -> "100F", -> 100F
+					explode $line
+					line="$( echo "$2" | cut -d'"' -f2 )"
+					line="devstatus: link ok $line"
+				}
+			elif command -v 'ethtool' >/dev/null; then
+				line="$( ethtool "$port" )"
+			elif command -v 'mii-tool' >/dev/null; then
 				line="$( mii-tool "$port" )"
+			else
+				break
 			fi
 
 			max_try=$(( max_try - 1 ))
@@ -152,7 +161,7 @@ _switch_query_miitool()		# SENSE: show a single switch-port of a 'mii-tool'-cont
 			"$port: no link"|*'Link detected: no'*)
 				_switch symbol down
 			;;
-			*"link ok"*|*'Link detected: yes'*)
+			*'link ok'*|*'Link detected: yes'*)
 				# "ethX: no autonegotiation, 100baseTx-HD, link ok"
 				# "ethX: 100 Mbit, full duplex, link ok"	// after: mii-tool --force=100baseTx-FD eth0
 				# "ethX: 100 Mbit, full duplex, no link"	// other side will not work
@@ -166,7 +175,7 @@ _switch_query_miitool()		# SENSE: show a single switch-port of a 'mii-tool'-cont
 				# Link detected: no (or) yes
 
 				case "$line" in
-					*'-FD,'*|*'-FD '*|*'full duplex'*|*'Duplex: Full'*)
+					*'-FD,'*|*'-FD '*|*'full duplex'*|*'Duplex: Full'*|*'0F')
 						duplex='full'
 					;;
 					*)
@@ -175,13 +184,13 @@ _switch_query_miitool()		# SENSE: show a single switch-port of a 'mii-tool'-cont
 				esac
 
 				case "$line" in
-					*' 1000baseT'*|*'1000 Mbit'*|*'Speed: 1000Mb/s'*)
+					*' 1000baseT'*|*'1000 Mbit'*|*'Speed: 1000Mb/s'*|*'1000'*)
 						_switch symbol $duplex 1000
 					;;
-					*' 100baseT'*|*'100 Mbit'*|*'Speed: 100Mb/s'*)
+					*' 100baseT'*|*'100 Mbit'*|*'Speed: 100Mb/s'*|*'100'*)
 						_switch symbol $duplex 100
 					;;
-					*' 10baseT'*|*'10 Mbit'*|*'Speed: 10Mb/s'*)
+					*' 10baseT'*|*'10 Mbit'*|*'Speed: 10Mb/s'*|*'10'*)
 						_switch symbol $duplex 10
 					;;
 					*)
@@ -214,7 +223,7 @@ _switch_show()		# SENSE: show all switch-ports, e.g. 'C.bB-C' = "1GB gap 100mbit
 	# the internal OpenWrt-name differs from our version
 	# for switch-related stuff this is enough, see:
 	# https://github.com/weimarnetz/weimarnetz/issues/16
-	read hw 2>/dev/null <'/tmp/sysinfo/model'
+	read -r hw 2>/dev/null <'/tmp/sysinfo/model'
 	case "$hw" in
 		'TP-Link Archer C7 v1') hw='TP-LINK Archer C7' ;;
 		'TP-Link TL-MR3020 v1') hw='TP-LINK TL-MR3020' ;;
@@ -225,7 +234,7 @@ _switch_show()		# SENSE: show all switch-ports, e.g. 'C.bB-C' = "1GB gap 100mbit
 		'TP-Link TL-WR841N/ND v8') hw='TP-LINK TL-WR841N/ND v8' ;;
 		'TP-Link TL-WR841N/ND v9') hw='TP-LINK TL-WR841N/ND v9' ;;
 		'TP-Link TL-WR842N/ND v1') hw='TP-LINK TL-WR842N/ND v1' ;;
-		'Ubiquiti Bullet M') hw='Ubiquiti Bullet M5' ;;
+		'Ubiquiti Bullet M') hw='Ubiquiti Bullet M' ;;
 		'Ubiquiti Nanostation M') hw='Ubiquiti Nanostation M5' ;;
 		*) hw="$HARDWARE" ;;
 	esac
@@ -240,9 +249,18 @@ _switch_show()		# SENSE: show all switch-ports, e.g. 'C.bB-C' = "1GB gap 100mbit
 				_switch query_swconfig '4 gap 3 2 1 0' "$debug"
 			fi
 		;;
+		'Xiaomi Miwifi mini')
+			# power | WAN | LAN2 | LAN1 | USB
+			_switch query_mii 'eth0' "$debug"
+			_switch query_swconfig 'gap 1 gap 0' "$debug"
+		;;
 		'Nexx WT3020'*)
 			# WAN | LAN | power
 			_switch query_swconfig '0 gap 4' "$debug"
+		;;
+		'TP-LINK CPE210'|'TP-LINK CPE220'|'TP-LINK CPE510'|'TP-LINK CPE520')
+			# LAN ("main") | WAN ("2nd")
+			_switch query_swconfig '5 gap 4' "$debug"
 		;;
 		'TP-LINK TL-WR1043ND'|'TP-LINK TL-WR841N/ND v7'|'TP-LINK TL-WR741ND v2'|'ASUS WL-500g Premium')
 			# WAN | 4 x LAN
@@ -259,39 +277,45 @@ _switch_show()		# SENSE: show all switch-ports, e.g. 'C.bB-C' = "1GB gap 100mbit
 		;;
 		'TP-LINK TL-WR841N/ND v8')
 			# WAN | 4 x LAN
-			_switch query_miitool 'eth0' "$debug"
+			_switch query_mii 'eth0' "$debug"
 			_switch query_swconfig 'gap 2 3 4 1' "$debug"
 		;;
 		'TP-LINK TL-WR940N'|'Mercury MAC1200R')
 			# WAN | 4 x LAN
-			_switch query_miitool 'eth1' "$debug"
+			_switch query_mii 'eth1' "$debug"
 			_switch query_swconfig 'gap 4 3 2 1' "$debug"
+		;;
+		'MQmaker WiTi')
+			# WAN1 | WAN2 | 4 x LAN
+			_switch query_mii "$WANDEV" "$debug"
+			_switch query_swconfig 'gap 5 gap 4 3 2 1' "$debug"
 		;;
 		'Buffalo WZR-HP-AG300H')
 			# WAN | 4 x LAN
-			_switch query_miitool 'eth1' "$debug"
+			_switch query_mii 'eth1' "$debug"
 			_switch query_swconfig 'gap 1 2 3 4' "$debug"
 		;;
 		'Ubiquiti Nanostation M'*)
 			# LAN ("main") | WAN ("secondary")
 			_switch query_swconfig '1' "$debug"
-			_switch query_miitool 'eth0' "$debug"
+			_switch query_mii 'eth0' "$debug"
 		;;
 		'Ubiquiti Nanostation'*|'TP-LINK TL-WR703N v1'|'Speedport W500V'|'T-Mobile InternetBox'|\
-		'Ubiquiti Picostation'*|'Ubiquiti Bullet M'*|'Ubiquiti Picostation M'*|'Seagate GoFlex Home')
-			_switch query_miitool 'eth0' "$debug"
+		'Ubiquiti Picostation'*|'Ubiquiti Bullet M'*|'Ubiquiti Picostation M'*|'Seagate GoFlex Home'|\
+		'D-Link DIR-505 A1'|'D-Link DIR-505L A1'|'D-Link DIR-505L A2')
+			_switch query_mii "${LANDEV:-$WANDEV}" "$debug"
 		;;
 		'PC Engines ALIX.2'|'Mikrotik Routerboard 532')		# TODO: rb532
 			# power | WAN | LAN | LAN2 | serial
-			_switch query_miitool "eth0 gap eth1 gap eth2" "$debug"
+			_switch query_mii "eth0 gap eth1 gap eth2" "$debug"
 		;;
 		'PC Engines WRAP')
-			# power | WAN | LAN | serial			# BOOTP via WAN
-			_switch query_miitool 'eth0 gap eth1' "$debug"
+			# power | LAN | WAN | serial			# BOOTP via WAN
+			_switch query_mii 'eth1 gap eth0' "$debug"
 		;;
 		'Soekris net5501')
 			# power | serial | WAN | LAN | LAN | LAN
-			_switch query_miitool 'eth0 eth1 eth2 eth3' "$debug"
+			_switch query_mii 'eth0 eth1 eth2 eth3' "$debug"
 		;;
 		'UML'|'Intel'*|'AMD Opteron'*|*'QEMU Virtual CPU'*|'x86_64'|*'ARMv7'*)
 			# sane (but maybe wrong) fallback for e.g. VPN-Server


### PR DESCRIPTION
…or include 'ethtool' or 'mii-tool' anymore