### PR TITLE
README: update web addresses and add package info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,4 @@
 
 - Report bugs or work on issues: https://github.com/weimarnetz/weimarnetz/issues 
 
-- Improve the documentation: https://github.com/weimarnetz/weimarnetz/wiki 
+- Improve the documentation: https://wireless.subsignal.org

--- a/README.md
+++ b/README.md
@@ -2,25 +2,40 @@ weimarnetz
 ==========
 
 * community: https://wireless.subsignal.org | https://weimarnetz.de
-* monitoring: https://weimarnetz.de/monitoring
-* documentation: [Wiki](https://github.com/weimarnetz/weimarnetz/wiki)
+* monitoring: https://weimarnetz.de/uebersicht-weimarnetz/status
+* documentation: [Wiki](https://wireless.subsignal.org)
 
 
 Need support?
-join the [club](http://www.weimarnetz.de).
+join the [club](https://weimarnetz.de).
+
+
+about
+-----
+
+Weimarnetz specific OpenWrt package `weimarnetz-ffwizard`.
+
 
 versions
 --------
 
-The `GebrannteMandeln` branch is the current stable version that is running on most routers (9/2017). The `master` branch is bleeding edge.
+The `brauhaus` branch is the current stable version that is running on most routers (6/2022). The `master` branch is bleeding edge.
 
 
 how to get a release for a specific hardware
 --------------------------------------------
 
-Use the firmware builder: 
+Use the packages repository:
 
-https://github.com/weimarnetz/firmware
+https://github.com/weimarnetz/packages
+
+
+how to get a release with a modified weimarnetz configuration
+-------------------------------------------------------------
+
+Modify the `Makefile` of the package:
+
+https://github.com/weimarnetz/packages/blob/brauhaus-19.07/utils/weimarnetz-ffwizard/Makefile
 
 
 Cherry Picking Git commits from forked repositories


### PR DESCRIPTION
Replace monitoring and Github wiki addresses:
* What was the content of the monitoring page? Is the status page a useful replacement?
* The weimarnetz Github wiki pages as unavailable / deactivated? Is the subsignal wiki a good starting point?

I hope the other changes and additions are useful, too.